### PR TITLE
Fixes warning in GitHub action for depreciated actions: Node.js 16 actions are deprecated...

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
     - name: Install dependencies
@@ -19,7 +19,7 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report


### PR DESCRIPTION
### Warning on GitHub Console:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

**Fix**
Move to version 4 as per the warning and [this article](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

**Screenshot Before fix:**
![warnings](https://github.com/microsoft/playwright-examples/assets/11694972/341944fd-5b2a-433a-be34-04affea30985)

Screenshot after fix (moving to v4 
![fixed](https://github.com/microsoft/playwright-examples/assets/11694972/bf950044-9224-4bf5-9078-926748e709d1)
version):
