### PR TITLE
Publish test results on GitHub pages

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
     - name: Install dependencies
@@ -19,7 +19,7 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,76 @@
-name: Playwright Tests
+# Simple workflow for running tests and deploying static html test reports to GitHub Pages
+name: Test and Publish results to GitHub Pages
+
 on:
+  # Runs on pushes targeting the default branch
   push:
-    branches: [ main ]
+    branches: ["main"]
+  
+  # Runs on pull requests to the default branch. actions/deploy-pages step would be skipped for PRs.
   pull_request:
     branches: [ main ]
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 18
-    - name: Install dependencies
-      run: npm ci
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
-    - name: Run Playwright tests
-      run: npx playwright test
-    - uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+  
+      - name: Install project dependencies
+        run: npm ci
+  
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+  
+      - name: Run Playwright tests
+        run: npx playwright test
+      
+      - name: Setup and Enable Pages
+        if: always()
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact playwright-report
+        if: always()
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'playwright-report'
+  
+  # Publish test results job
+  publish-results:
+    # Add a dependency to the test job
+    needs: test
+    if: always()
+    
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo is used to demonstrate various testing scenarios with [Playwright](https://playwright.dev/) 🎭 with Node.js.
 
-## Run Playwright example tests
+## 🚀 Getting started
 
 ### Install dependencies
 
@@ -12,13 +12,22 @@ Start by cloning the repo and installing the dependencies:
 npm install
 ```
 
+ ### Run Playwright example tests
 Use the [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) to run the tests in the tests folder from VS Code or run the following command in the terminal:
 
 ```bash
 npx playwright test --ui
 ```
 
-## Contributing
+## 🐞 Playwright Test report 
+
+Test report URL for the latest run in CI is available in the run itself and here: https://microsoft.github.io/playwright-examples/
+
+> [!NOTE]
+> For the above report to be available, as a one time measure, a project admin or maintainer has to manually enable `Pages` settings to use `GithHub Actions` as a source for `Build and Deployment`. The detailed steps are mentioned in github official docs [here: Required steps are from step 1 till 4. Step 5 is to be skipped, since we already have workflow in our repository](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow). 
+
+
+## 🫱🏻‍🫲🏾 Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
@@ -32,7 +41,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-## Trademarks
+## ™ Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
 trademarks or logos is subject to and must follow 


### PR DESCRIPTION
### Problem statement:

In the current GitHub workflow, the test report is made available as a zip archive; which requires users to first download it, unarchive it and then view it from their local machine. 

Idea is to make the report immediately available to users by publishing it on Projects GitHub Pages: https://microsoft.github.io/playwright-examples/ 

### Solution:

By using official GitHub actions as specified [here](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site), I updated the workflow to publish html test result artefact both as a zip file and also on GitHub pages. 

> There is a small one time effort required to update the project settings for the actions to be able to publish results on GitHub Pages. The instructions for this are listed in both readme file and also on official docs [here](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow). 

### Tests

Since I am not a project admin or maintainer of microsoft/playwright-examples/ repo, I tried this solution on a personal Sandbox project and found it to be working correct for both below tested scenarios:

- When all tests are green. 
![pass-results](https://github.com/microsoft/playwright-examples/assets/11694972/62c6a6eb-937a-41ec-bd15-29c31ec07818)

- When there are test failures.
<img width="679" alt="fail-results" src="https://github.com/microsoft/playwright-examples/assets/11694972/fbf93c46-9bd7-4092-8cb1-f7ac6447f65f">

I think this would really improve the user experience of testers who use GitHub actions as a solution. 